### PR TITLE
Make the creation of the repository optional + python3

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -3,6 +3,7 @@
     "base_release"   : [ "AnalysisBase", "AthAnalysis", "Hybrid" ],
     "contact_person" : "The (main) contact for this analysis",
     "contact_email"  : "E-mail address of the (main) contact",
+    "create_repo"    : "y",
     "gitlab_name"    : "The (CERN/GitLab) user/group name of the project's owner",
     "analysis_id"    : "The Glance ID for the analysis, if it has one",
     "short_descr"    : "Short description for the project",


### PR DESCRIPTION
I think it is nice to push people to put their code under git, but sometimes (e.g. quicktest, ...) you don't want to do it.

   * Ask y/n to create the repository (code factored into a function)
   * python3: iteritems -> items, open files as binary

Ruggero